### PR TITLE
DVC-8137: Ignore prereleases when selecting previous release to increment

### DIFF
--- a/gh-release/action.yml
+++ b/gh-release/action.yml
@@ -26,6 +26,8 @@ runs:
       with:
         latest: true
         prerelease: false
+      env:
+        GITHUB_TOKEN: ${{ inputs.github-token }}
     - name: Get next minor version
       id: semverbump
       uses: WyriHaximus/github-action-next-semvers@v1.2.1

--- a/gh-release/action.yml
+++ b/gh-release/action.yml
@@ -20,16 +20,17 @@ runs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - name: Get Previous semver tag
-      id: previoustag
-      uses: WyriHaximus/github-action-get-previous-tag@v1.3.0
+    - name: Get latest non-prerelease release
+      id: latestrelease
+      uses: cardinalby/git-get-release-action@v1
       with:
-        prefix: v
+        latest: true
+        prerelease: false
     - name: Get next minor version
       id: semverbump
       uses: WyriHaximus/github-action-next-semvers@v1.2.1
       with:
-        version: ${{ steps.previoustag.outputs.tag }}
+        version: ${{ steps.latestrelease.outputs.tag_name }}
     - name: Build Changelog
       id: changelog
       uses: mikepenz/release-changelog-builder-action@v3


### PR DESCRIPTION
The previous action used for fetching the latest release was looking at raw tags, and not skipping prereleases.