### PR TITLE
Update deprecated actions

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -23,7 +23,7 @@ jobs:
  release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           token: ${{ secrets.AUTOMATION_USER_TOKEN }}
           fetch-depth: 0

--- a/create-release/action.yml
+++ b/create-release/action.yml
@@ -38,7 +38,7 @@ runs:
         TAG: ${{ inputs.tag }}
     - name: Create Release
       id: create-release
-      uses: mikepenz/action-gh-release@v0.2.0-a03
+      uses: softprops/action-gh-release@v2.0.4
       with:
         tag_name: ${{ steps.tag-prefixed.outputs.tag }}
         body: ${{ inputs.changelog }}

--- a/gh-release/action.yml
+++ b/gh-release/action.yml
@@ -24,7 +24,7 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Get latest non-prerelease release

--- a/gh-release/action.yml
+++ b/gh-release/action.yml
@@ -43,7 +43,7 @@ runs:
         version: ${{ steps.latestrelease.outputs.tag_name }}
     - name: Build Changelog
       id: changelog
-      uses: mikepenz/release-changelog-builder-action@v3
+      uses: mikepenz/release-changelog-builder-action@v4.2.2
       with:
         ignorePreReleases: true
       env:

--- a/gh-release/action.yml
+++ b/gh-release/action.yml
@@ -66,7 +66,7 @@ runs:
         echo "::notice title=Tag::Tag for release: ${TAG} ${DRAFT}"
         echo "tag=$TAG" >> "$GITHUB_OUTPUT"
     - name: Create Release
-      uses: mikepenz/action-gh-release@v0.2.0-a03
+      uses: softprops/action-gh-release@v2.0.4
       with:
         tag_name: ${{ steps.tag.outputs.tag }}
         body: ${{steps.changelog.outputs.changelog}}

--- a/prepare-release/action.yml
+++ b/prepare-release/action.yml
@@ -66,7 +66,7 @@ runs:
         echo "tag=$TAG" >> "$GITHUB_OUTPUT"
     - name: Build Changelog
       id: changelog
-      uses: mikepenz/release-changelog-builder-action@v3.7.2
+      uses: mikepenz/release-changelog-builder-action@v4.2.2
       with:
         # explicitly specify the tag range to use to avoid inconsistency in the changelog
         fromTag: ${{ steps.latestrelease.outputs.tag_name }}


### PR DESCRIPTION
- update release-changelog-builder-action to v4.2.2 (latest)
- update softprops/action-gh-release to v2.0.4 (latest) (we were using an alpha version previously)
- updates checkout to v4 (latest)