### PR TITLE
chore: Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,4 +1,8 @@
 name: Test Release Action
+permissions:
+  contents: write
+  pull-requests: write
+  actions: read
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/DevCycleHQ/release-action/security/code-scanning/1](https://github.com/DevCycleHQ/release-action/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the least privileges required. Based on the workflow's operations, the following permissions are necessary:
- `contents: write` for pushing changes to the repository.
- `pull-requests: write` for interacting with pull requests (if applicable).
- `actions: read` for accessing workflow artifacts.

We will add the `permissions` block at the root level of the workflow to apply it to all jobs. If any job requires additional permissions, they can be defined specifically within that job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
